### PR TITLE
Initial Zookeeper configuration.

### DIFF
--- a/utils/containers/confd/Dockerfile.rancher
+++ b/utils/containers/confd/Dockerfile.rancher
@@ -1,0 +1,3 @@
+FROM scratch
+
+ADD ./confd-0.11.0-dev-rancher-linux-amd64 /confd

--- a/zookeeper/README.md
+++ b/zookeeper/README.md
@@ -1,0 +1,36 @@
+# (Alpha) Zookeeper Service
+
+
+This compose file will create a three node Zookeeper cluster. It is designed to run on Rancher and consume the Rancer Metadata service. 
+
+
+### Usage
+
+This compose file will bring up a cluster of Zookeeper clusters that make it simple to get the unique ID and IP addresses of the nodes in the cluster. 
+
+In bootstrapping this template though, you need to bring the service up by running:
+
+`rancher-compose -p zookeeper up`
+
+This will create the three nodes, but given the way the metadata service currently works, nodes 1 and 2 will not have all the host/container entries.
+
+In order for the configuration to be consistent, you need to run:
+
+`rancher-compose -p zookeeper restart`
+
+After that, the service should be configured properly for use.
+
+
+### Metadata
+
+The zookeeper-config service is using a rancher build confd binary.
+
+It makes use of the following keys:
+
+/self/container/create_index - The index of the container as it was created in the service.
+
+/self/service/containers - A list of all container names in the service.
+
+/containers/<name>/create_index - the index of the container as it was created in the service.
+
+/containers/<name>/primary_ip - The primary IP (assigned by Rancher) of the container.

--- a/zookeeper/containers/zookeeper-config/Dockerfile
+++ b/zookeeper/containers/zookeeper-config/Dockerfile
@@ -1,0 +1,9 @@
+FROM rancher/confd-base:0.11.0-dev-rancher
+
+ADD ./conf.d /etc/confd/conf.d
+ADD ./templates /etc/confd/templates
+
+VOLUME ["/var/lib/zookeeper", "/opt/zookeeper/conf/"]
+
+ENTRYPOINT ["/confd"]
+CMD ["--backend", "rancher", "--prefix", "/2015-07-25"]

--- a/zookeeper/containers/zookeeper-config/conf.d/myid.toml
+++ b/zookeeper/containers/zookeeper-config/conf.d/myid.toml
@@ -1,0 +1,9 @@
+[template]
+prefix = "/self/container"
+src = "myid.tmpl"
+dest = "/var/lib/zookeeper/myid"
+owner = "root"
+mode = "0644"
+keys = [
+  "/create_index",
+]

--- a/zookeeper/containers/zookeeper-config/conf.d/zoo.cfg.toml
+++ b/zookeeper/containers/zookeeper-config/conf.d/zoo.cfg.toml
@@ -1,0 +1,9 @@
+[template]
+src = "zoo.cfg.tmpl"
+dest = "/opt/zookeeper/conf/zoo.cfg"
+owner = "root"
+mode = "0644"
+keys = [
+  "/self/service/containers",
+  "/containers",
+]

--- a/zookeeper/containers/zookeeper-config/templates/myid.tmpl
+++ b/zookeeper/containers/zookeeper-config/templates/myid.tmpl
@@ -1,0 +1,1 @@
+{{getv "/create_index"}}

--- a/zookeeper/containers/zookeeper-config/templates/zoo.cfg.tmpl
+++ b/zookeeper/containers/zookeeper-config/templates/zoo.cfg.tmpl
@@ -1,0 +1,9 @@
+tickTime=2000
+initLimit=10
+syncLimit=5
+dataDir=/var/lib/zookeeper
+clientPort=2181
+autopurge.snapRetainCount=3
+autopurge.purgeInterval=1
+{{range ls "/self/service/containers"}}{{ $containerName := getv (printf "/self/service/containers/%s" .)}}
+server.{{getv (printf "/containers/%s/create_index" $containerName)}}={{getv (printf "/containers/%s/primary_ip" $containerName)}}:2888:3888{{end}}

--- a/zookeeper/containers/zookeeper/Dockerfile
+++ b/zookeeper/containers/zookeeper/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:jessie
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openjdk-7-jre-headless
+
+ADD entry.sh /entry.sh
+
+ADD http://mirror.metrocast.net/apache/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz /opt/
+RUN cd /opt && \
+    tar -zxvf zookeeper-3.4.6.tar.gz && \
+    mv zookeeper-3.4.6 zookeeper && \
+    rm -rf ./zookeeper-*tar.gz && \
+    mkdir -p /var/lib/zookeeper
+
+WORKDIR /opt/zookeeper
+EXPOSE 2181 2888 3888
+VOLUME ["/var/lib/zookeeper", "/opt/zookeeper/conf", "/tmp/zookeeper"]
+
+ENTRYPOINT ["/entry.sh"]

--- a/zookeeper/containers/zookeeper/README.md
+++ b/zookeeper/containers/zookeeper/README.md
@@ -1,0 +1,21 @@
+## Zookeeper Container
+
+----
+This container runs a stock zookeeper 3.6 instance.
+
+It leverages confd to populate the config files. Given the way Zookeeper 
+To use the container it is initialized via like so:
+
+```
+ docker run -d --net=host --name=zookeeper \
+ -e SERVICES_ZOOKEEPER_MYID=<int> \
+ -e SERVICES_ZOOKEEPER_HOST_1='{"Id": "1", "Ip": "<ip>"}' \
+ -e SERVICES_ZOOKEEPER_HOST_2='{"Id": "<n>", "Ip": "<ip>"}' \
+ rancher/zookeeer 
+```
+
+The container will setup ports on 2181,2888,3888 on the host.
+
+Each node in the zookeeper cluster will need an entry, and the ID/IP pairs must be the same for all hosts.
+
+The `network = host` so that ZK can bind to the instances IP.

--- a/zookeeper/containers/zookeeper/entry.sh
+++ b/zookeeper/containers/zookeeper/entry.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+while [ ! -f "/var/lib/zookeeper/myid" ]; do
+    sleep 1
+done
+
+exec /opt/zookeeper/bin/zkServer.sh start-foreground

--- a/zookeeper/docker-compose.yml
+++ b/zookeeper/docker-compose.yml
@@ -1,0 +1,10 @@
+zookeeper-config:
+  image: rancher/zookeeper-config:v0.1.0
+  volumes_from:
+    - zookeeper
+  net: "container:zookeeper"
+zookeeper:
+  labels:
+    io.rancher.sidekicks: zookeeper-config
+    io.rancher.scheduler.affinity:host_label: zk=rancher
+  image: rancher/zookeeper:3.4.6-1

--- a/zookeeper/rancher-compose.yml
+++ b/zookeeper/rancher-compose.yml
@@ -1,0 +1,2 @@
+zookeeper:
+  scale: 3


### PR DESCRIPTION
This is consuming metadata with a proposed version of Confd
on the backend. A couple of things need to be overcome, when
the service is started, the first two containers will not
have all of the server entries. You need to restart the service
in order to get a consistent config, but it does run after that.
