### PR TITLE
Fixed 50% failure rate due to deadlock

### DIFF
--- a/glusterfs/0.1.3/docker-compose.yml
+++ b/glusterfs/0.1.3/docker-compose.yml
@@ -1,0 +1,39 @@
+glusterfs-server:
+  image: rancher/glusterfs:v0.1.3
+  devices:
+    - /dev/fuse:/dev/fuse:rwm
+  cap_add:
+    - SYS_ADMIN
+  volumes_from:
+    - glusterfs-data
+  labels:
+    io.rancher.container.hostname_override: container_name
+    io.rancher.sidekicks: glusterfs-peer,glusterfs-data,glusterfs-volume-create
+    io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/glusterfs-server
+  command: "glusterd -p /var/run/gluster.pid -N"
+glusterfs-peer:
+  image: rancher/glusterfs:v0.1.3
+  net: 'container:glusterfs-server'
+  volumes_from:
+    - glusterfs-data
+  labels:
+    io.rancher.container.hostname_override: container_name
+  command: /opt/rancher/peerprobe.sh
+glusterfs-data:
+  image: rancher/glusterfs:v0.1.3
+  net: none
+  command: /bin/true
+  volumes:
+    - /var/run
+  labels:
+    io.rancher.container.hostname_override: container_name
+    io.rancher.container.start_once: true
+glusterfs-volume-create:
+  image: rancher/glusterfs:v0.1.3
+  command: /opt/rancher/replicated_volume_create.sh
+  net: 'container:glusterfs-server'
+  volumes_from:
+    - glusterfs-data
+  labels:
+    io.rancher.container.hostname_override: container_name
+    io.rancher.container.start_once: true

--- a/glusterfs/0.1.3/rancher-compose.yml
+++ b/glusterfs/0.1.3/rancher-compose.yml
@@ -1,0 +1,4 @@
+glusterfs-server:
+  scale: 3
+  metadata:
+    volume_name: "my_vol"

--- a/glusterfs/containers/0.1.3/glusterfs/Dockerfile
+++ b/glusterfs/containers/0.1.3/glusterfs/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:7
+
+RUN yum install -y wget && \
+    wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm && \
+    rpm -ivh epel-release-7-5.noarch.rpm && \
+    wget -P /etc/yum.repos.d http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/glusterfs-epel.repo && \
+    yum install -y glusterfs-server glusterfs glusterfs-fuse jq curl
+
+VOLUME ["/data/glusterfs/brick1"]
+
+ADD ./*.sh /opt/rancher/
+
+EXPOSE 24007
+EXPOSE 24007/udp
+EXPOSE 24008
+EXPOSE 24008/udp
+
+# One brick model
+EXPOSE 49152
+
+CMD ["glusterd", "-p", "/var/run/glusterd.pid", "-N"]

--- a/glusterfs/containers/0.1.3/glusterfs/common.sh
+++ b/glusterfs/containers/0.1.3/glusterfs/common.sh
@@ -1,0 +1,8 @@
+wait_for_all_service_containers()
+{
+    META_URL="${1:-http://rancher-metadata/2015-07-25}"
+    SET_SCALE=$(curl -s -H 'Accept: application/json' ${META_URL}/self/service| jq -r .scale)
+    while [ "$(curl -s -H 'Accept: application/json' ${META_URL}/self/service|jq '.containers |length')" -lt "${SET_SCALE}" ]; do
+        sleep 1
+    done    
+}

--- a/glusterfs/containers/0.1.3/glusterfs/lowest_idx.sh
+++ b/glusterfs/containers/0.1.3/glusterfs/lowest_idx.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+###
+# Detect if this container has the lowest create ID
+###
+
+META_URL="http://rancher-metadata/2015-07-25"
+
+ALLMETA=$(curl -s -H 'Accept: application/json' ${META_URL})
+MY_CREATE_INDEX="$(echo ${ALLMETA} | jq -r .self.container.create_index)"
+
+get_create_index()
+{
+    echo $(echo ${ALLMETA}| jq -r ".containers[]| select(.name==\"${1}\")| .create_index")
+}
+
+SMALLEST="${MY_CREATE_INDEX}"
+for container in $(echo ${ALLMETA}| jq -r .self.service.containers[]); do
+    IDX=$(get_create_index "${container}")
+    if [ "${IDX}" -lt "${SMALLEST}" ]; then
+        SMALLEST=${IDX}
+    fi
+done
+
+if [ "${MY_CREATE_INDEX}" -eq "${SMALLEST}" ]; then
+  exit 0
+fi
+
+exit 1

--- a/glusterfs/containers/0.1.3/glusterfs/peerprobe.sh
+++ b/glusterfs/containers/0.1.3/glusterfs/peerprobe.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+. /opt/rancher/common.sh
+
+META_URL="http://rancher-metadata/2015-07-25"
+SELF_NAME=$(curl -s -H 'Accept: application/json' ${META_URL}/self/container| jq -r .name)
+
+echo "Waiting for all service containers to start..."
+wait_for_all_service_containers
+echo "Containers are starting..."
+
+# let the services come up
+echo "Waiting for Gluster Daemons to come up"
+sleep 30
+
+peer_probe_hosts()
+{    
+    for peer in $(curl -s -H 'Accept: application/json' ${META_URL}/self/service| jq -r .containers[]); do
+        if [ "${peer}" != "${SELF_NAME}" ]; then
+            IP=$(curl -s -H 'Accept: application/json' ${META_URL}/containers/${peer}|jq -r .primary_ip)
+            echo gluster peer probe ${IP}
+            gluster peer probe ${IP}
+            sleep .5
+        fi
+    done
+}
+
+random_sleep()
+{
+    SLEEP_TIME=$RANDOM
+    let "SLEEP_TIME %= 15"
+    sleep ${SLEEP_TIME}
+}
+
+
+while true; do
+    PEER_COUNT=$(gluster pool list|grep -v UUID|wc -l)
+    if [ "$(curl -s -H 'Accept: application/json' ${META_URL}/self/service| jq -r .scale)" -ne "${PEER_COUNT}" ]; then
+        # avoid possible race condition...
+        random_sleep
+        peer_probe_hosts
+    fi
+    sleep 15
+done

--- a/glusterfs/containers/0.1.3/glusterfs/replicated_volume_create.sh
+++ b/glusterfs/containers/0.1.3/glusterfs/replicated_volume_create.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+. /opt/rancher/common.sh
+
+echo "Waiting for all containers to come up..."
+wait_for_all_service_containers
+echo "Containers are coming up..."
+
+META_URL="http://rancher-metadata/2015-07-25"
+
+ALLMETA=$(curl -s -H 'Accept: application/json' ${META_URL})
+VOLUME_NAME=$(echo ${ALLMETA} | jq -r '.self.service.metadata.volume_name')
+BRICK_PATH="/data/glusterfs/brick1"
+VOLUME_PATH="${BRICK_PATH}/${VOLUME_NAME}"
+REPLICA_COUNT=$(echo ${ALLMETA} | jq -r '.self.service.scale')
+
+if [ ! -f ${VOLUME_PATH} ]; then
+    mkdir -p "${VOLUME_PATH}"
+fi
+
+## Check if this is the Lowest create index
+/opt/rancher/lowest_idx.sh
+if [ "$?" -ne "0" ]; then
+    echo "The lowest numbered container handles volume operations... I'm not the lowest"
+    exit 0
+fi
+
+while [ "$(gluster pool list | grep Connected | wc -l)" -lt "${REPLICA_COUNT}" ]; do
+    echo "Waiting for pool..."
+    sleep 5
+done
+
+echo "Waiting for peerprobes and gluster daemons to come on line"
+sleep 35
+
+echo "Getting peer mount points..."
+STATE_READY="true"
+while true; do
+    CONTAINER_MNTS=""
+
+    for container in $(curl -s -H 'Accept: application/json' ${META_URL} | jq '.self.service.containers[]'); do
+        IP=$(curl -s -H 'Accept: application/json' ${META_URL} | jq -r ".containers[] | select(.name==${container}) | .primary_ip")
+
+        if [ "$(gluster --remote-host=${IP} pool list | grep Connected | wc -l)" -ne "${REPLICA_COUNT}" ]; then
+            echo "Peer mounts not ready...will retry"
+            STATE_READY="false"
+            continue
+        fi
+
+        CONTAINER_MNTS="$CONTAINER_MNTS ${IP}:${VOLUME_PATH}"
+    done
+
+    if [ "${STATE_READY}" = "true" ]; then
+        break
+    fi
+    sleep 5
+done
+
+if [ "$(gluster volume info ${VOLUME_NAME}|grep 'does\ not\ exist'|wc -l)" -ne "1" ]; then
+    echo "Creating volume ${VOLUME_NAME}..."
+    gluster volume create ${VOLUME_NAME} replica ${REPLICA_COUNT} transport tcp ${CONTAINER_MNTS}
+    sleep 5
+fi
+
+if [ "$(gluster volume info ${VOLUME_NAME}| grep ^Status | tr -d '[[:space:]]' | cut -d':' -f2)" = "Created" ]; then
+    echo "Starting volume ${VOLUME_NAME}..."
+    gluster volume start ${VOLUME_NAME}
+fi


### PR DESCRIPTION
The first two containers were in lockstep with each other, and
in a common situation, the nodes would peer probe each other at
roughly the same time causing Gluster to always respond with errors.
