### PR TITLE
Rancher v0.4.0 elasticsearch container changes to support elasticsearch v2.1.1

### DIFF
--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/Dockerfile
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/Dockerfile
@@ -1,0 +1,12 @@
+FROM rancher/confd-base:0.11.0-dev-rancher
+
+ADD ./conf.d /etc/confd/conf.d
+ADD ./templates /etc/confd/templates
+ADD ./run.sh /opt/rancher/bin/
+
+VOLUME /usr/share/elasticsearch/config
+VOLUME /data/confd
+VOLUME /opt/rancher/bin
+
+ENTRYPOINT ["/confd"]
+CMD ["--backend", "rancher", "--prefix", "/2015-07-25"]

--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/conf.d/elasticsearch.toml
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/conf.d/elasticsearch.toml
@@ -1,0 +1,7 @@
+[template]
+src = "elasticsearch.tmpl"
+dest = "/usr/share/elasticsearch/config/elasticsearch.yml"
+keys = [
+  "/self",
+  "/containers",
+]

--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/conf.d/logging.toml
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/conf.d/logging.toml
@@ -1,0 +1,6 @@
+[template]
+src = "logging.tmpl"
+dest = "/usr/share/elasticsearch/config/logging.yml"
+keys = [
+  "/elasticsearch/log/",
+]

--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/conf.d/plugins.toml
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/conf.d/plugins.toml
@@ -1,0 +1,6 @@
+[template]
+src = "plugins.tmpl"
+dest = "/data/confd/plugins.txt"
+keys = [
+  "/elasticsearch/plugins/",
+]

--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/run.sh
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+PLUGIN_TXT=${PLUGIN_TXT:-/usr/share/elasticsearch/plugins.txt}
+
+while [ ! -f "/usr/share/elasticsearch/config/elasticsearch.yml" ]; do
+    sleep 1
+done
+
+mkdir -p /usr/share/elasticsearch/config/scripts
+
+if [ -f "$PLUGIN_TXT" ]; then
+    for plugin in $(<"${PLUGIN_TXT}"); do
+        /usr/share/elasticsearch/bin/plugin --install $plugin
+    done
+fi
+
+exec /docker-entrypoint.sh elasticsearch

--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/templates/elasticsearch.tmpl
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/templates/elasticsearch.tmpl
@@ -1,0 +1,15 @@
+#datanodei Placed by confd. Do not hand edit.
+{{range ls "/self/service/metadata/elasticsearch/yml"}}
+{{.}}: {{getv (printf "/self/service/metadata/elasticsearch/yml/%s" .)}}{{end}}
+
+bootstrap.mlockall: true
+discovery.zen.ping.multicast.enabled: false
+
+network.host: {{getv "/self/container/primary_ip"}}
+
+{{with get "/self/service/name"}}{{if eq "elasticsearch-masters" .Value}}
+discovery.zen.ping.unicast.hosts: {{range ls "/self/service/containers"}}{{ $containerName := getv (printf "/self/service/containers/%s" .)}}
+  - {{getv (printf "/containers/%s/primary_ip" $containerName)}}{{end}}
+{{else}}
+discovery.zen.ping.unicast.hosts: ["es-masters"]
+{{end}}{{end}}

--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/templates/logging.tmpl
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/templates/logging.tmpl
@@ -1,0 +1,21 @@
+# Placed by confd. Do not hand edit.
+{{if exists "/elasticsearch/log"}}
+{{range gets "/elasticsearch/log/*"}}{{ $data := json .Value}}{{range $key, $value := $data}}
+{{$key}}: {{$value}}{{end}}{{end}}
+{{else}}
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+{{end}}

--- a/elasticsearch/containers/0.5.0/elasticsearch-conf/templates/plugins.tmpl
+++ b/elasticsearch/containers/0.5.0/elasticsearch-conf/templates/plugins.tmpl
@@ -1,0 +1,2 @@
+{{if exists "/elasticsearch/plugins"}}{{range $dir := ls "/elasticsearch/plugins"}}{{getv (printf "%s/%s" "/elasticsearch/plugins" $dir)}}
+{{end}}{{end}}

--- a/elasticsearch/containers/0.5.0/kopf/Dockerfile
+++ b/elasticsearch/containers/0.5.0/kopf/Dockerfile
@@ -1,0 +1,27 @@
+FROM nginx:1.9.4
+
+# upgrade
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends python-pip curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install envtpl
+
+# nginx
+ADD nginx.conf.tpl /etc/nginx/nginx.conf.tpl
+
+# run script
+ADD ./run.sh ./run.sh
+
+# kopf
+ENV KOPF_VERSION 2.1.1
+RUN curl -s -L "https://github.com/lmenezes/elasticsearch-kopf/archive/v${KOPF_VERSION}.tar.gz" | \
+    tar xz -C /tmp && mv "/tmp/elasticsearch-kopf-${KOPF_VERSION}" /kopf
+
+# logs
+VOLUME ["/var/log/nginx"]
+
+# ports
+EXPOSE 80 443
+
+ENTRYPOINT ["/run.sh"]

--- a/elasticsearch/containers/0.5.0/kopf/README.md
+++ b/elasticsearch/containers/0.5.0/kopf/README.md
@@ -1,0 +1,59 @@
+# Kopf in docker
+
+Tagged docker images for kopf, `lmenezes/elasticsearch-kopf` on docker hub.
+
+## Usage
+
+Use `docker run` as you always do. You need to publish port `80`
+(and `443` if you use ssl) in order to have access to kopf.
+
+Container should have access to elasticsearch. You don't
+need to expose elasticsearch to end users of kopf.
+
+It is strongly recommended to use https and basic auth
+if you don't want to get hacked.
+
+### Env variables.
+
+* `KOPF_SERVER_NAME` server name for your grafana, for example `kopf.example.com`
+* `KOPF_ES_SERVERS` elasticsearch servers in `host:port[,host:port]` format
+* `KOPF_SSL_CERT` path to ssl `.crt` file, enables http-to-https redirect, should be bind-mounted
+* `KOPF_SSL_KEY` path to ssl `.key` file, should be bind-mounted
+* `KOPF_BASIC_AUTH_LOGIN` basic auth login, if needed
+* `KOPF_BASIC_AUTH_PASSWORD` hashed basic auth password, if needed
+* `KOPF_NGINX_INCLUDE_FILE` file to include into main server of nginx (place allowed ips here)
+* `KOPF_WITH_CREDENTIALS` set the external setting with_credentials. Default: false
+* `KOPF_THEME` set the theme in external settings. Default: dark
+* `KOPF_REFRESH_RATE` set the external setting refresh_rate. Default: 5000
+
+### Example
+
+#### pure docker run
+
+Running kopf with elasticsearch on `es.dev:9200`,
+exposing it on `kopf.dev` with ip address `10.10.10.10`:
+
+```
+docker run -d -p 10.10.10.10:80:80 -e KOPF_SERVER_NAME=grafana.dev \
+    -e KOPF_ES_SERVERS=es.dev:9200 --name kopf lmenezes/elasticsearch-kopf
+```
+#### fig
+
+An easy way to orchestrate a local docker run is fig
+Install fig by fireing up ```pip install fig```.
+After create a fig file and off you go. 
+```
+$ cat << EOF > fig.yml
+kopf:
+  image: lmenezes/elasticsearch-kopf
+  ports:
+  - 8080:80
+  environment:
+  - KOPF_SERVER_NAME=dockerhost
+  - KOPF_ES_SERVERS=172.17.42.1:9200
+EOF
+$ fig up -d
+Creating docker_kopf_1...
+$
+```
+This docker container will connect to an ES instance running on the DOCKER_HOST, which exposes 9200.

--- a/elasticsearch/containers/0.5.0/kopf/nginx.conf.tpl
+++ b/elasticsearch/containers/0.5.0/kopf/nginx.conf.tpl
@@ -1,0 +1,76 @@
+daemon off;
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  access_log /dev/stdout;
+  error_log /dev/stderr;
+
+  upstream es {
+    {% for server in KOPF_ES_SERVERS.split(",") %}
+    server {{ server }};
+    {% endfor %}
+  }
+
+  {% if KOPF_SSL_CERT is defined %}
+  server {
+    listen 80;
+    server_name {{ KOPF_SERVER_NAME }};
+    return 301 https://{{ KOPF_SERVER_NAME }}$request_uri;
+  }
+  {% endif %}
+
+  server {
+    {% if KOPF_SSL_CERT is defined %}
+    listen 443 ssl;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_certificate {{ KOPF_SSL_CERT }};
+    ssl_certificate_key {{ KOPF_SSL_KEY }};
+    {% else %}
+    listen 80;
+    {% endif %}
+
+    server_name {{ KOPF_SERVER_NAME }};
+
+    satisfy any;
+
+    {% if KOPF_BASIC_AUTH_LOGIN is defined %}
+    auth_basic "Access restricted";
+    auth_basic_user_file /etc/nginx/kopf.htpasswd;
+    {% endif %}
+
+    {% if KOPF_NGINX_INCLUDE_FILE is defined %}
+    include {{ KOPF_NGINX_INCLUDE_FILE }};
+    {% endif %}
+
+    # suppress passing basic auth to upstreams
+    proxy_set_header Authorization "";
+
+    # everybody loves caching bugs after upgrade
+    expires -1;
+
+    location / {
+      root /kopf/_site;
+    }
+
+    location /es/ {
+      rewrite ^/es/(.*)$ /$1 break;
+      proxy_pass http://es;
+    }
+  }
+}

--- a/elasticsearch/containers/0.5.0/kopf/run.sh
+++ b/elasticsearch/containers/0.5.0/kopf/run.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+envtpl --keep-template /etc/nginx/nginx.conf.tpl
+
+if [ ! -z "${KOPF_BASIC_AUTH_LOGIN}" ]; then
+    echo "${KOPF_BASIC_AUTH_LOGIN}:${KOPF_BASIC_AUTH_PASSWORD}" > /etc/nginx/kopf.htpasswd
+fi
+
+KOPF_REFRESH_RATE="${KOPF_REFRESH_RATE:-5000}"
+KOPF_THEME="${KOPF_THEME:-dark}"
+KOPF_WITH_CREDENTIALS="${KOPF_WITH_CREDENTIALS:-false}"
+
+cat <<EOF > /kopf/_site/kopf_external_settings.json
+{
+    "elasticsearch_root_path": "/es",
+    "with_credentials": ${KOPF_WITH_CREDENTIALS},
+    "theme": "${KOPF_THEME}",
+    "refresh_rate": ${KOPF_REFRESH_RATE}
+}
+EOF
+
+exec nginx

--- a/elasticsearch/containers/0.5.0/kopf/run.sh
+++ b/elasticsearch/containers/0.5.0/kopf/run.sh
@@ -14,7 +14,7 @@ KOPF_WITH_CREDENTIALS="${KOPF_WITH_CREDENTIALS:-false}"
 
 cat <<EOF > /kopf/_site/kopf_external_settings.json
 {
-    "elasticsearch_root_path": "/es",
+    "elasticsearch_root_path": "/es/",
     "with_credentials": ${KOPF_WITH_CREDENTIALS},
     "theme": "${KOPF_THEME}",
     "refresh_rate": ${KOPF_REFRESH_RATE}


### PR DESCRIPTION
# Changes from 0.4.0
## _run.sh_

**elasticsearch-conf** doesn't create elasticsearch's _/config/scripts/_ directory.  In versions prior to v2 this wasn't an issue, but now it is (elasticsearch v2 won't start without it).  Since I couldn't figure out a way to get the directory created in the Docker file, _run.sh_ now specifically creates it.
## _conf.d/elasticsearch.toml_ / _templates/elasticsearch.tmpl_

elasticsearch prior to v2 automatically listened on all addresses (0.0.0.0).  v2 changed this to only listen on localhost (127.0.0.1) automatically (i.e. more secure by default).  SysAdmin now has to specify an address in the config file.
## _kopf/Dockerfile_

Pull kopf v2.1.1.
