### PR TITLE
Update Jenkins Swarm container

### DIFF
--- a/jenkins_swarm_clients/0.2.0/docker-compose.yml
+++ b/jenkins_swarm_clients/0.2.0/docker-compose.yml
@@ -1,0 +1,16 @@
+swarm-clients:
+  image: "rancher/jenkins-swarm:v0.2.0"
+  user: "root"
+  labels:
+    io.rancher.scheduler.global: "true"
+    #io.rancher.scheduler.affinity:host_label_soft: ci=worker
+  external_links:
+    - "jenkins-ci/jenkins-primary:jenkins-primary"
+  environment:
+    JENKINS_PASS: "${jenkins_pass}"
+    JENKINS_USER: "${jenkins_user}"
+    SWARM_EXECUTORS: "${swarm_executors}"
+  volumes:
+    - '/var/run/docker.sock:/var/run/docker.sock'
+    - '/var/jenkins_home/workspace:/var/jenkins_home/workspace'
+    - '/tmp:/tmp'

--- a/jenkins_swarm_clients/container/0.2.0/jenkins-swarm/Dockerfile
+++ b/jenkins_swarm_clients/container/0.2.0/jenkins-swarm/Dockerfile
@@ -1,0 +1,16 @@
+FROM jenkins:1.625.3
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates libapparmor-dev
+ADD ./run.sh /run.sh
+
+ENV SWARM_CLIENT_VERSION 2.0
+ADD http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/${SWARM_CLIENT_VERSION}/swarm-client-${SWARM_CLIENT_VERSION}-jar-with-dependencies.jar /usr/share/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar
+RUN chmod 644 /usr/share/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar
+RUN curl -s -L https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker; chmod +x /usr/bin/docker
+
+USER jenkins
+WORKDIR /var/jenkins_home
+
+ENTRYPOINT ["/run.sh"]

--- a/jenkins_swarm_clients/container/0.2.0/jenkins-swarm/run.sh
+++ b/jenkins_swarm_clients/container/0.2.0/jenkins-swarm/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SWARM_ARGS=""
+if [ -n "${JENKINS_USER}" ]; then
+    SWARM_ARGS="${SWARM_ARGS} -username ${JENKINS_USER}"
+fi
+
+if [ -n "${JENKINS_PASS}" ]; then
+    SWARM_ARGS="${SWARM_ARGS} -passwordEnvVariable JENKINS_PASS"
+fi
+
+if [ -n "${SWARM_EXECUTORS}" ]; then
+    SWARM_ARGS="${SWARM_ARGS} -executors ${SWARM_EXECUTORS}"
+fi
+
+exec java -jar /usr/share/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar -fsroot /var/jenkins_home ${SWARM_ARGS} -master http://jenkins-primary:${JENKINS_PORT:-8080}


### PR DESCRIPTION
Package Docker 1.9.1 inside container.
Bind mount in /var/jenkins_home so other containers
have access to workspace.
Bind mount in /tmp because the build env plugin requires it.
