### PR TITLE
Fix create failure with REPLICA_COUNT <= 1

### DIFF
--- a/glusterfs/containers/0.2.1/glusterfs/Dockerfile
+++ b/glusterfs/containers/0.2.1/glusterfs/Dockerfile
@@ -1,11 +1,11 @@
 FROM centos:7
 
-RUN yum install -y wget && \
-    wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm && \
-    rpm -ivh epel-release-7-5.noarch.rpm && \
-    wget -P /etc/yum.repos.d http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/glusterfs-epel.repo && \
-    yum install -y glusterfs-server glusterfs glusterfs-fuse jq curl && \
-    mv /var/lib/glusterd/hooks/1/set/post/S30samba-set.sh /var/lib/glusterd/hooks/1/set/post/dS30samba-set.sh && \
+RUN yum install -y wget
+RUN wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm && \
+    rpm -ivh epel-release-7-6.noarch.rpm
+RUN wget -P /etc/yum.repos.d http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/glusterfs-epel.repo && \
+    yum install -y glusterfs-server glusterfs glusterfs-fuse jq curl
+RUN mv /var/lib/glusterd/hooks/1/set/post/S30samba-set.sh /var/lib/glusterd/hooks/1/set/post/dS30samba-set.sh && \
     mv /var/lib/glusterd/hooks/1/start/post/S30samba-start.sh /var/lib/glusterd/hooks/1/start/post/dS30samba-start.sh && \
     mv /var/lib/glusterd/hooks/1/stop/pre/S30samba-stop.sh /var/lib/glusterd/hooks/1/stop/pre/dS30samba-stop.sh
 

--- a/glusterfs/containers/0.2.1/glusterfs/replicated_volume_create.sh
+++ b/glusterfs/containers/0.2.1/glusterfs/replicated_volume_create.sh
@@ -55,7 +55,14 @@ CONTAINER_MNTS=$(giddyup ip stringify --delimiter " " --suffix ":${VOLUME_PATH}"
 
 if [ "$(gluster volume info ${VOLUME_NAME}|grep 'does\ not\ exist'|wc -l)" -ne "1" ]; then
     echo "Creating volume ${VOLUME_NAME}..."
-    gluster volume create ${VOLUME_NAME} replica ${REPLICA_COUNT} transport tcp ${CONTAINER_MNTS}
+
+    if [ "$REPLICA_COUNT" -gt "1" ]; then
+        REPLICA_ARG="replica ${REPLICA_COUNT}"
+    else
+        REPLICA_ARG=""
+    fi
+
+    gluster volume create ${VOLUME_NAME} ${REPLICA_ARG} transport tcp ${CONTAINER_MNTS}
     sleep 5
 fi
 


### PR DESCRIPTION
The `glusterfs-volume-create` container will fail to create the initial volume for `catalog/community:convoy-glusterfs` if rancher-compose `scale: 1`.
