### PR TITLE
Kopf2

### DIFF
--- a/elasticsearch/containers/0.4.0/kopf/Dockerfile
+++ b/elasticsearch/containers/0.4.0/kopf/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.9.4
+FROM nginx:1.11.1
 
 # upgrade
 RUN apt-get update && \
@@ -14,7 +14,7 @@ ADD nginx.conf.tpl /etc/nginx/nginx.conf.tpl
 ADD ./run.sh ./run.sh
 
 # kopf
-ENV KOPF_VERSION 1.5.7
+ENV KOPF_VERSION 2.1.2
 RUN curl -s -L "https://github.com/lmenezes/elasticsearch-kopf/archive/v${KOPF_VERSION}.tar.gz" | \
     tar xz -C /tmp && mv "/tmp/elasticsearch-kopf-${KOPF_VERSION}" /kopf
 

--- a/elasticsearch/containers/0.4.0/kopf/nginx.conf.tpl
+++ b/elasticsearch/containers/0.4.0/kopf/nginx.conf.tpl
@@ -69,8 +69,10 @@ http {
     }
 
     location /es/ {
-      rewrite ^/es/(.*)$ /$1 break;
-      proxy_pass http://es;
+      proxy_pass http://es/;
+    }
+    location = /es {
+      proxy_pass http://es/;
     }
   }
 }


### PR DESCRIPTION
- update kopf 2.1.2.
  kopf 2 is need for compatibility with elasticsearch 2.x
- also fix "Error loading cluster data" when kopf is mapped to a port != 80 / 443 on host (ex = 8000).
  This error is caused by nginx redirecting `<host>:8000/es` to `<host>/es/`
