### PR TITLE
Etcd v2.3.7, HealthCheck proxy

### DIFF
--- a/etcd/containers/0.10.0/etcd/Dockerfile
+++ b/etcd/containers/0.10.0/etcd/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.3
+
+RUN \
+  apk add --update bash ca-certificates && \
+  rm -rf /var/cache/apk/* && \
+  wget -q -O /usr/local/bin/giddyup https://github.com/cloudnautique/giddyup/releases/download/v0.13.0/giddyup && \
+  chmod +x /usr/local/bin/giddyup
+
+RUN \
+  wget -q -O - https://github.com/coreos/etcd/releases/download/v2.3.6/etcd-v2.3.6-linux-amd64.tar.gz | tar xzf - -C /tmp && \
+  mv /tmp/etcd-*/etcd /usr/local/bin/etcd && \
+  mv /tmp/etcd-*/etcdctl /usr/local/bin/etcdctl && \
+  rm -rf /tmp/etcd-* && rm -f /etcd-*.tar.gz
+
+ADD run.sh /run.sh
+ADD disaster /usr/bin/disaster
+
+ENTRYPOINT ["/run.sh"]
+CMD ["node"]

--- a/etcd/containers/0.10.0/etcd/Dockerfile
+++ b/etcd/containers/0.10.0/etcd/Dockerfile
@@ -7,11 +7,12 @@ RUN \
   chmod +x /usr/local/bin/giddyup
 
 RUN \
-  wget -q -O - https://github.com/coreos/etcd/releases/download/v2.3.6/etcd-v2.3.6-linux-amd64.tar.gz | tar xzf - -C /tmp && \
+  wget -q -O - https://github.com/coreos/etcd/releases/download/v2.3.7/etcd-v2.3.7-linux-amd64.tar.gz | tar xzf - -C /tmp && \
   mv /tmp/etcd-*/etcd /usr/local/bin/etcd && \
   mv /tmp/etcd-*/etcdctl /usr/local/bin/etcdctl && \
   rm -rf /tmp/etcd-* && rm -f /etcd-*.tar.gz
 
+ADD etcdhc /usr/bin/etcdhc
 ADD run.sh /run.sh
 ADD disaster /usr/bin/disaster
 

--- a/etcd/containers/0.10.0/etcd/Dockerfile.hcproxy
+++ b/etcd/containers/0.10.0/etcd/Dockerfile.hcproxy
@@ -1,0 +1,10 @@
+FROM golang:alpine
+
+RUN apk update && apk add git
+RUN go get github.com/urfave/cli
+
+RUN mkdir -p /go/src/etcdhc
+WORKDIR /go/src/etcdhc
+ADD hcproxy.go .
+
+RUN go build

--- a/etcd/containers/0.10.0/etcd/build
+++ b/etcd/containers/0.10.0/etcd/build
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ACCT=${ACCT:-llparse}
-VERSION=${VERSION:-v2.3.7-4}
+VERSION=${VERSION:-v2.3.7-5}
 
 docker build -t hcproxy -f Dockerfile.hcproxy .
 id=$(docker run -d --entrypoint=/bin/sh --name hcproxy hcproxy sleep 15)

--- a/etcd/containers/0.10.0/etcd/build
+++ b/etcd/containers/0.10.0/etcd/build
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ACCT=${ACCT:-llparse}
-VERSION=${VERSION:-v2.3.7-3}
+VERSION=${VERSION:-v2.3.7-4}
 
 docker build -t hcproxy -f Dockerfile.hcproxy .
 id=$(docker run -d --entrypoint=/bin/sh --name hcproxy hcproxy sleep 15)

--- a/etcd/containers/0.10.0/etcd/build
+++ b/etcd/containers/0.10.0/etcd/build
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ACCT=${ACCT:-llparse}
-VERSION=${VERSION:-v2.3.7}
+VERSION=${VERSION:-v2.3.7-2}
 
 docker build -t hcproxy -f Dockerfile.hcproxy .
 id=$(docker run -d --entrypoint=/bin/sh --name hcproxy hcproxy sleep 15)

--- a/etcd/containers/0.10.0/etcd/build
+++ b/etcd/containers/0.10.0/etcd/build
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ACCT=${ACCT:-llparse}
-VERSION=${VERSION:-v2.3.7-5}
+VERSION=${VERSION:-v2.3.7-6}
 
 docker build -t hcproxy -f Dockerfile.hcproxy .
 id=$(docker run -d --entrypoint=/bin/sh --name hcproxy hcproxy sleep 15)

--- a/etcd/containers/0.10.0/etcd/build
+++ b/etcd/containers/0.10.0/etcd/build
@@ -1,10 +1,17 @@
-#!/bin/bash
+#!/bin/bash -e
 
 ACCT=${ACCT:-llparse}
-VERSION=${VERSION:-v2.3.6-4}
+VERSION=${VERSION:-v2.3.7}
+
+docker build -t hcproxy -f Dockerfile.hcproxy .
+id=$(docker run -d --entrypoint=/bin/sh --name hcproxy hcproxy sleep 15)
+docker cp hcproxy:/go/src/etcdhc/etcdhc .
+docker rm -f $id
 
 docker build -t $ACCT/etcd:$VERSION .
 docker push $ACCT/etcd:$VERSION
+
+rm -f etcdhc
 
 if [ "$(which gsync)" ]; then
   gsync $ACCT/etcd:$VERSION

--- a/etcd/containers/0.10.0/etcd/build
+++ b/etcd/containers/0.10.0/etcd/build
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ACCT=${ACCT:-llparse}
-VERSION=${VERSION:-v2.3.7-2}
+VERSION=${VERSION:-v2.3.7-3}
 
 docker build -t hcproxy -f Dockerfile.hcproxy .
 id=$(docker run -d --entrypoint=/bin/sh --name hcproxy hcproxy sleep 15)

--- a/etcd/containers/0.10.0/etcd/build
+++ b/etcd/containers/0.10.0/etcd/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ACCT=${ACCT:-llparse}
+VERSION=${VERSION:-v2.3.6-4}
+
+docker build -t $ACCT/etcd:$VERSION .
+docker push $ACCT/etcd:$VERSION
+
+if [ "$(which gsync)" ]; then
+  gsync $ACCT/etcd:$VERSION
+fi

--- a/etcd/containers/0.10.0/etcd/disaster
+++ b/etcd/containers/0.10.0/etcd/disaster
@@ -9,6 +9,9 @@ echo -e "Disaster flag set.\n\nTriggering disaster recovery...this will automati
 
 sleep 1
 
-kill $(pidof etcd)
-
-sleep 2
+# Continuously send SIGTERM
+PID=$(pidof etcd)
+while kill -0 $PID &> /dev/null; do
+  kill $PID
+  sleep 1
+done

--- a/etcd/containers/0.10.0/etcd/disaster
+++ b/etcd/containers/0.10.0/etcd/disaster
@@ -2,9 +2,10 @@
 
 BACKUP_DIR=${BACKUP_DIR:-/data.backup}
 
-echo -e "You seem to be having a bad day. Sorry about that.\n\nCreating backup..."
+mkdir -p $BACKUP_DIR
 
-etcdctl backup --data-dir $ETCD_DATA_DIR --backup-dir $BACKUP_DIR
+echo -e "Disaster flag set.\n\nTriggering disaster recovery...this will automatically restart the container."
 
-echo -e "Complete.\n\nPlease restart (DO NOT DELETE) this container to begin disaster recovery."
-echo -e "Once this is completed, add more hosts to scale your etcd cluster."
+sleep 3
+
+kill $(pidof etcd)

--- a/etcd/containers/0.10.0/etcd/disaster
+++ b/etcd/containers/0.10.0/etcd/disaster
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-BACKUP_DIR=${BACKUP_DIR:-/data.backup}
+DATA_DIR=/data
+DR_FLAG=${DATA_DIR}/DR
 
-mkdir -p $BACKUP_DIR
+mkdir -p $DR_FLAG
 
 echo -e "Disaster flag set.\n\nTriggering disaster recovery...this will automatically restart the container."
 
-sleep 3
+sleep 1
 
 kill $(pidof etcd)
+
+sleep 2

--- a/etcd/containers/0.10.0/etcd/disaster
+++ b/etcd/containers/0.10.0/etcd/disaster
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+BACKUP_DIR=${BACKUP_DIR:-/data.backup}
+
+echo -e "You seem to be having a bad day. Sorry about that.\n\nCreating backup..."
+
+etcdctl backup --data-dir $ETCD_DATA_DIR --backup-dir $BACKUP_DIR
+
+echo -e "Complete.\n\nPlease restart (DO NOT DELETE) this container to begin disaster recovery."
+echo -e "Once this is completed, add more hosts to scale your etcd cluster."

--- a/etcd/containers/0.10.0/etcd/hcproxy.go
+++ b/etcd/containers/0.10.0/etcd/hcproxy.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+  "github.com/urfave/cli"
+  "errors"
+  "fmt"
+  "net"
+  "net/http"
+  "net/url"
+  "time"
+  "os"
+  "log"
+)
+
+func main() {
+  app := cli.NewApp()
+  app.Name = "Etcd healthcheck proxy"
+  app.Usage = "Ensure Etcd's raft index has caught up with the cluster before reporting healthy"
+  app.Commands = []cli.Command{
+    ProxyCommand(),
+  }
+  app.Run(os.Args)
+}
+
+func ProxyCommand() cli.Command {
+  return cli.Command{
+    Name:  "proxy",
+    Usage: "Proxy health checks after a waiting period",
+    Action: ProxyAction,
+    Flags: []cli.Flag{
+      cli.StringFlag{
+        Name:  "port, p",
+        Usage: "Port address to serve proxied health checks on",
+        Value: ":2378",
+      },
+      // This feature flag is to be used for etcd v2.3.7 and earlier
+      cli.DurationFlag{
+        Name:  "wait",
+        Usage: "Wait for a period of time before proxying health checks",
+        Value: 120 * time.Second,
+      },
+      // This feature flag is to be used for etcd v3.0.0 and later
+      cli.BoolFlag{
+        Name:  "raft",
+        Usage: "Wait for raft indeces to all be in range (requires etcd version >= v3.0.0)",
+      },
+      cli.BoolFlag{
+        Name:  "debug",
+        Usage: "Verbose logging information for debugging purposes",
+        EnvVar: "RANCHER_DEBUG",
+      },
+    },
+  }
+}
+
+func ProxyAction(c *cli.Context) error {
+  http.HandleFunc("/health", func (w http.ResponseWriter, r *http.Request) {
+    err := HealthCheck("tcp://127.0.0.1:2379", 5 * time.Second)
+
+    if err == nil {
+      fmt.Fprintf(w, "OK")
+      if c.Bool("debug") {
+        log.Println("OK")
+      }
+    } else {
+      http.Error(w, err.Error(), http.StatusServiceUnavailable)
+      if c.Bool("debug") {
+        log.Println(err.Error())
+      }
+    }
+  })
+
+  time.Sleep(c.Duration("wait"))
+  // TODO (llparse): determine when raft index has caught up with other nodes in metadata
+  return http.ListenAndServe(c.String("port"), nil)
+}
+
+func HealthCheck(endpoint string, timeout time.Duration) error {
+  url, err := url.Parse(endpoint)
+  if err != nil {
+    return err
+  }
+
+  switch url.Scheme {
+  case "tcp":
+    var conn net.Conn
+    if conn, err = net.DialTimeout(url.Scheme, url.Host, timeout); err != nil {
+      return err
+    }
+    conn.Close()
+  case "http", "https":
+    client := &http.Client{
+      Timeout: timeout,
+    }
+    var resp *http.Response
+    resp, err = client.Get(endpoint)
+
+    switch {
+    case err != nil:
+      return err
+    case resp.StatusCode >= 200 && resp.StatusCode <= 299:
+      return nil
+    default:
+      return errors.New(fmt.Sprintf("HTTP %d\n", resp.StatusCode))
+    }
+  default:
+    return errors.New(fmt.Sprintf("Unsupported URL scheme: %s\n", url.Scheme))
+  }
+  return nil
+}

--- a/etcd/containers/0.10.0/etcd/run.sh
+++ b/etcd/containers/0.10.0/etcd/run.sh
@@ -36,7 +36,12 @@ etcdctln() {
     fi
 }
 
+healthcheck_proxy() {
+    /usr/bin/etcdhc proxy --port=:2378 --wait=60s &
+}
+
 standalone_node() {
+    healthcheck_proxy
     etcd \
         --name ${NAME} \
         --listen-client-urls http://0.0.0.0:2379 \
@@ -48,6 +53,7 @@ standalone_node() {
 }
 
 restart_node() {
+    healthcheck_proxy
     etcd \
         --name ${NAME} \
         --listen-client-urls http://0.0.0.0:2379 \
@@ -92,6 +98,7 @@ runtime_node() {
 
     etcdctln member add $NAME http://${IP}:2380
 
+    healthcheck_proxy
     etcd \
         --name ${NAME} \
         --listen-client-urls http://0.0.0.0:2379 \
@@ -123,6 +130,7 @@ recover_node() {
 
     etcdctln member add $NAME http://${IP}:2380
 
+    healthcheck_proxy
     etcd \
         --name ${NAME} \
         --listen-client-urls http://0.0.0.0:2379 \

--- a/etcd/containers/0.10.0/etcd/run.sh
+++ b/etcd/containers/0.10.0/etcd/run.sh
@@ -144,12 +144,7 @@ disaster_node() {
     echo "Sanitizing DR backup..."
     etcd \
         --name ${NAME} \
-        --listen-client-urls http://0.0.0.0:2379 \
-        --advertise-client-urls http://${IP}:2379 \
-        --listen-peer-urls http://0.0.0.0:2380 \
-        --initial-advertise-peer-urls http://${IP}:2380 \
-        --initial-cluster ${NAME}=http://${IP}:2380 \
-        --data-dir ${BACKUP_DIR} \
+        --data-dir $BACKUP_DIR \
         --force-new-cluster &
     PID=$!
 

--- a/etcd/containers/0.10.0/etcd/run.sh
+++ b/etcd/containers/0.10.0/etcd/run.sh
@@ -37,7 +37,7 @@ etcdctln() {
 }
 
 healthcheck_proxy() {
-    /usr/bin/etcdhc proxy --port=:2378 --wait=60s &
+    /usr/bin/etcdhc proxy --port=:2378 --wait=60s --debug=false &
 }
 
 standalone_node() {

--- a/etcd/containers/0.10.0/etcd/run.sh
+++ b/etcd/containers/0.10.0/etcd/run.sh
@@ -118,7 +118,7 @@ recover_node() {
             cluster=${cluster},
         fi
         cluster=${cluster}${name}=${peer_url}
-    done <<< "$(etcdctl member list | grep -v unstarted)"
+    done <<< "$(etcdctln member list | grep -v unstarted)"
     cluster=${cluster},${NAME}=http://${IP}:2380
 
     etcdctln member add $NAME http://${IP}:2380
@@ -187,6 +187,12 @@ node() {
     # if the DR flag is set, enter disaster recovery
     if [ -d "$DR_FLAG" ]; then
         disaster_node
+
+    # for previous versions, we had a different FS structure that must be upgraded
+    elif [ -d "$DATA_DIR/member" ]; then
+        mkdir -p $ETCD_DATA_DIR
+        mv $DATA_DIR/member $ETCD_DATA_DIR/
+        node
 
     # if we have a data volume, we are upgrading/restarting
     elif [ -d "$ETCD_DATA_DIR/member" ]; then

--- a/etcd/containers/0.10.0/etcd/run.sh
+++ b/etcd/containers/0.10.0/etcd/run.sh
@@ -166,9 +166,9 @@ disaster_node() {
         etcdctl member update $oldnode http://${IP}:2380
     done
 
-    # shutdown the disaster node cleanly
-    kill $PID
+    # shutdown the node cleanly
     while kill -0 $PID &> /dev/null; do
+        kill $PID
         sleep 1
     done
 

--- a/etcd/containers/0.10.0/etcd/run.sh
+++ b/etcd/containers/0.10.0/etcd/run.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+if [ "$RANCHER_DEBUG" == "true" ]; then set -x; fi
+
+BACKUP_DIR=${BACKUP_DIR:-/data.backup}
+DISCOVERY=http://discovery:6666
+SCALE=$(giddyup service scale etcd)
+
+IP=$(giddyup ip myip)
+META_URL="http://rancher-metadata.rancher.internal/2015-12-19"
+STACK_NAME=$(wget -q -O - ${META_URL}/self/stack/name)
+CREATE_INDEX=$(wget -q -O - ${META_URL}/self/container/create_index)
+NAME=$(wget -q -O - ${META_URL}/self/container/name)
+export ETCDCTL_ENDPOINT=http://etcd.${STACK_NAME}:2379
+
+etcdctld() {
+    etcdctl --no-sync --endpoints $DISCOVERY $@
+}
+
+etcdctln() {
+    target=0
+    for j in $(seq 1 5); do
+        for i in $(seq 1 $SCALE); do
+            giddyup probe http://${STACK_NAME}_etcd_${i}:2379/health &> /dev/null
+            if [ "$?" == "0" ]; then
+                target=$i
+                break
+            fi
+        done
+        if [ "$target" != "0" ]; then
+            break
+        fi
+        sleep 1
+    done
+    if [ "$target" == "0" ]; then
+        echo No etcd nodes available
+    else
+        etcdctl --endpoints http://${STACK_NAME}_etcd_$target:2379 $@
+    fi
+}
+
+discovery_node() {
+    etcd \
+        -name discovery \
+        -advertise-client-urls http://${IP}:6666 \
+        -listen-client-urls http://0.0.0.0:6666
+}
+
+standalone_node() {
+    etcd \
+        --name ${NAME} \
+        --listen-client-urls http://0.0.0.0:2379 \
+        --advertise-client-urls http://${IP}:2379 \
+        --listen-peer-urls http://0.0.0.0:2380 \
+        --initial-advertise-peer-urls http://${IP}:2380 \
+        --initial-cluster ${NAME}=http://${IP}:2380 \
+        --initial-cluster-state new
+}
+
+restart_node() {
+    # Runtime reconfigure the IP address in case retain_ip isn't set and we are upgrading
+    oldnode=$(etcdctln member list | grep "$NAME" | tr ':' '\n' | head -1)
+    etcdctln member update $oldnode http://${IP}:2380
+
+    etcd \
+        --name ${NAME} \
+        --listen-client-urls http://0.0.0.0:2379 \
+        --advertise-client-urls http://${IP}:2379 \
+        --listen-peer-urls http://0.0.0.0:2380 \
+        --initial-advertise-peer-urls http://${IP}:2380 \
+        --initial-cluster-state existing
+}
+
+# Scale Up
+runtime_node() {
+
+    # Get leader create_index
+    # Wait for nodes with smaller service index to become healthy
+    for container in $(giddyup service containers --exclude-self); do
+        echo Waiting for lower index nodes to all be active
+        ctx_index=$(wget -q -O - ${META_URL}/self/service/containers/${container}/create_index)
+        if [ "${ctx_index}" -lt "${CREATE_INDEX}" ]; then
+            giddyup probe http://${container}:2379/health --loop --min 1s --max 60s --backoff 1.1
+        fi
+    done
+
+    # We can almost use giddyup here, need service index templating {{service_index}}
+    # giddyup ip stringify --prefix etcd{{service_index}}=http:// --suffix :2380
+    # etcd1=http://10.42.175.109:2380,etcd2=http://10.42.58.73:2380,etcd3=http://10.42.96.222:2380
+    for container in $(wget -q -O - ${META_URL}/self/service/containers); do
+        meta_index=$(echo $container | tr '=' '\n' | head -n1)
+        ctx_index=$(wget -q -O - ${META_URL}/self/service/containers/${meta_index}/create_index)
+        container_name=$(wget -q -O - ${META_URL}/self/service/containers/${meta_index}/name)
+
+        # simulate step-scale policy by ignoring create_indeces greater than our own
+        if [ "${ctx_index}" -gt "${CREATE_INDEX}" ]; then
+            continue
+        fi
+
+        cip=$(wget -q -O - ${META_URL}/self/service/containers/${meta_index}/primary_ip)
+        if [ "$cluster" != "" ]; then
+            cluster=${cluster},
+        fi
+        cluster=${cluster}${container_name}=http://${cip}:2380
+    done
+
+    etcdctln member add $NAME http://${IP}:2380
+
+    etcd \
+        --name ${NAME} \
+        --listen-client-urls http://0.0.0.0:2379 \
+        --advertise-client-urls http://${IP}:2379 \
+        --listen-peer-urls http://0.0.0.0:2380 \
+        --initial-advertise-peer-urls http://${IP}:2380 \
+        --initial-cluster-state existing \
+        --initial-cluster $cluster
+}
+
+# failure scenario
+recover_node() {
+    # figure out which node we are replacing
+    oldnode=$(etcdctln member list | grep "$NAME" | tr ':' '\n' | head -1)
+
+    # remove the old node
+    etcdctln member remove $oldnode
+
+    # create cluster parameter based on etcd state (can't use rancher metadata)
+    while read -r member; do
+        name=$(echo $member | tr ' ' '\n' | grep name | tr '=' '\n' | tail -1)
+        peer_url=$(echo $member | tr ' ' '\n' | grep peerURLs | tr '=' '\n' | tail -1)
+        if [ "$cluster" != "" ]; then
+            cluster=${cluster},
+        fi
+        cluster=${cluster}${name}=${peer_url}
+    done <<< "$(etcdctl member list | grep -v unstarted)"
+    cluster=${cluster},${NAME}=http://${IP}:2380
+
+    etcdctln member add $NAME http://${IP}:2380
+
+    etcd \
+        --name ${NAME} \
+        --listen-client-urls http://0.0.0.0:2379 \
+        --advertise-client-urls http://${IP}:2379 \
+        --listen-peer-urls http://0.0.0.0:2380 \
+        --initial-advertise-peer-urls http://${IP}:2380 \
+        --initial-cluster-state existing \
+        --initial-cluster $cluster
+}
+
+disaster_node() {
+    etcd \
+        --name ${NAME} \
+        --listen-client-urls http://0.0.0.0:2379 \
+        --advertise-client-urls http://${IP}:2379 \
+        --listen-peer-urls http://0.0.0.0:2380 \
+        --initial-advertise-peer-urls http://${IP}:2380 \
+        --initial-cluster ${NAME}=http://${IP}:2380 \
+        --data-dir ${BACKUP_DIR} \
+        --force-new-cluster &
+    PID=$!
+
+    # wait until the backup dir has been sanitized
+    giddyup probe http://127.0.0.1:2379/health --loop --min 1s --max 60s --backoff 1.1
+
+    # for some reason, disaster recovery ignores peer-urls flag so we update it
+    oldnode=$(etcdctln member list | grep "$NAME" | tr ':' '\n' | head -1)
+    etcdctl member update $oldnode http://${IP}:2380
+
+    # kill the disaster node
+    while kill -0 $PID &> /dev/null; do
+        kill $PID
+        sleep 1
+    done
+
+    # archive old data directory
+    mv $ETCD_DATA_DIR ${ETCD_DATA_DIR}.old
+
+    # copy the sanitized backup to the data directory
+    cp -rf $BACKUP_DIR/* $ETCD_DATA_DIR/
+
+    # move the backup so we don't re-enter disaster recovery
+    mv $BACKUP_DIR ${BACKUP_DIR}.sanitized
+
+    # become a new standalone node
+    standalone_node
+}
+
+node() {
+    # if we have a backup volume, we are recovering from a disaster
+    if [ -d "$BACKUP_DIR/member" ]; then
+        disaster_node
+
+    # if we have a data volume, we are upgrading/restarting
+    elif [ -d "$ETCD_DATA_DIR/member" ]; then
+        restart_node
+
+    elif giddyup leader check; then
+        standalone_node
+
+    # if this member is already registered to the cluster but no data volume, we are recovering
+    elif [ "$(etcdctln member list | grep $NAME)" != "" ]; then
+        recover_node
+
+    # we are scaling up
+    else
+        runtime_node
+    fi
+}
+
+if [ $# -eq 0 ]; then
+    echo No command specified, running in standalone mode.
+    standalone_node
+else
+    eval $1
+fi

--- a/etcd/containers/0.10.0/etcd/run.sh
+++ b/etcd/containers/0.10.0/etcd/run.sh
@@ -155,15 +155,15 @@ disaster_node() {
 
     # query etcd for its old member ID
     while [ "$oldnode" == "" ]; do
-        oldnode=$(etcdctl member list | grep "$NAME" | tr ':' '\n' | head -1)
+        oldnode=$(etcdctl --endpoints=http://127.0.0.1:2379 member list | grep "$NAME" | tr ':' '\n' | head -1)
         sleep 1
     done
     
     # etcd says it is healthy, but writes fail for a while...so keep trying until it works
-    etcdctl member update $oldnode http://${IP}:2380
+    etcdctl --endpoints=http://127.0.0.1:2379 member update $oldnode http://${IP}:2380
     while [ "$?" != "0" ]; do
         sleep 1
-        etcdctl member update $oldnode http://${IP}:2380
+        etcdctl --endpoints=http://127.0.0.1:2379 member update $oldnode http://${IP}:2380
     done
 
     # shutdown the node cleanly


### PR DESCRIPTION
Ready for merge

HC proxy with tunable wait for automated upgrade support without breaking quorum

This is the best we can do for etcd v2.3.7 and lower versions without implementing special onUpgrade trigger logic in cattle.

In etcd v3.0.0 and later, the raft index is exposed clientside and we can write code to ensure that raft indeces of upgraded nodes have caught up with the other members of the cluster. This will be in the next release.
