### PR TITLE
update the drone containers for version 0.5

### DIFF
--- a/drone/containers/0.5/drone-config/Dockerfile
+++ b/drone/containers/0.5/drone-config/Dockerfile
@@ -1,0 +1,22 @@
+#FROM nrvale0/drone-debug:0.5
+FROM alpine:3.4
+
+LABEL vendor="Rancher Labs, Inc." \
+	com.rancher.version="0.5" \
+	com.rancher.repo="https://github.com/rancher/catalog-dockerfiles"
+
+ENV GIDDYUP_VERSION='v0.14.0' CONFD_VERSION='v0.11.0'
+
+RUN apk add --update bash && rm -rf /var/cache/apk/*
+
+ADD ./confd/ /etc/confd/
+
+ADD "https://github.com/cloudnautique/giddyup/releases/download/${GIDDYUP_VERSION}/giddyup /giddyup"
+ADD "https://github.com/rancher/confd/releases/download/${CONFD_VERSION/confd-${CONFD_VERSION}-amd64 /confd"
+ADD /scripts/*.sh /opt/rancher/scripts/
+
+RUN chmod +x /confd /giddyup /opt/rancher/scripts/*
+
+ENTRYPOINT ["/opt/rancher/scripts/rancher_drone-config_entrypoint.sh", "server"]
+
+ADD Dockerfile /opt/rancher/

--- a/drone/containers/0.5/drone-config/confd/agent/conf.d/dronerc.toml
+++ b/drone/containers/0.5/drone-config/confd/agent/conf.d/dronerc.toml
@@ -1,0 +1,6 @@
+[template]
+src="dronerc.tmpl"
+dest="/etc/drone/dronerc"
+keys = [
+  "/self"
+]

--- a/drone/containers/0.5/drone-config/confd/agent/templates/dronerc.tmpl
+++ b/drone/containers/0.5/drone-config/confd/agent/templates/dronerc.tmpl
@@ -1,0 +1,6 @@
+{{ if exists "/self/service/metadata/debug_mode" }}
+export DRONE_DEBUG='{{ getv "/self/service/metadata/debug_mode" }}'
+{{ end }}
+
+export DRONE_SERVER='http://drone:{{ getv "/self/service/metadata/drone_service_tcp_port" }}'
+{{ getv "/self/service/metadata/dronerc_contents" }}

--- a/drone/containers/0.5/drone-config/confd/server/conf.d/dronerc.toml
+++ b/drone/containers/0.5/drone-config/confd/server/conf.d/dronerc.toml
@@ -1,0 +1,6 @@
+[template]
+src="dronerc.tmpl"
+dest="/etc/drone/dronerc"
+keys = [
+  "/self"
+]

--- a/drone/containers/0.5/drone-config/confd/server/templates/dronerc.tmpl
+++ b/drone/containers/0.5/drone-config/confd/server/templates/dronerc.tmpl
@@ -1,0 +1,5 @@
+{{ if exists "/self/service/metadata/debug_mode" }}
+export DRONE_DEBUG='{{ getv "/self/service/metadata/debug_mode" }}'
+{{ end }}
+
+{{ getv "/self/service/metadata/dronerc_contents" }}

--- a/drone/containers/0.5/drone-config/scripts/rancher_drone-config_entrypoint.sh
+++ b/drone/containers/0.5/drone-config/scripts/rancher_drone-config_entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ 'agent' == "$1" ] || [ 'server' == "$1" ]; then
+  echo "$0: Starting drone in $1 mode..."
+else
+  echo "$0: Must specify mode of 'agent' or 'server'." >&2 ; exit -1
+fi
+
+confd_cmd='/confd -backend=rancher -prefix=/2015-07-25'
+
+if [ -n "${DEBUG}" ]; then
+    extra_confd_opts='-log-level=debug'
+    ${confd_cmd} ${extra_confd_opts} -noop -onetime
+fi
+
+exec ${confd_cmd} ${extra_confd_opts} -confdir="/etc/confd/$1"

--- a/drone/containers/0.5/drone-debug/Dockerfile
+++ b/drone/containers/0.5/drone-debug/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+MAINTAINER Nathan Valentine < nathan@rancher.com | nrvale0@gmail.com >
+
+ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+
+RUN apt-get update && apt-get dist-upgrade -y && \
+	rm -rf /var/cache/apt/archive
+RUN apt-get install -y mysql-client nmap python-pip curl wget vim bash && \
+	rm -rf /var/cache/apt/archive
+RUN pip install httpie
+
+CMD /bin/bash

--- a/drone/containers/0.5/drone/Dockerfile
+++ b/drone/containers/0.5/drone/Dockerfile
@@ -1,0 +1,40 @@
+# Build the drone executable on a x64 Linux host:
+#
+#     go build --ldflags '-extldflags "-static"' -o drone_static
+#
+#
+# Alternate command for Go 1.4 and older:
+#
+#     go build -a -tags netgo --ldflags '-extldflags "-static"' -o drone_static
+#
+#
+# Build the docker image:
+#
+#     docker build --rm=true -t drone/drone .
+
+## Built from cloudnautique/drone fork on github.
+
+#FROM nrvale0/drone-debug:0.5
+FROM alpine:3.4
+
+LABEL vendor="Rancher Labs, Inc" \
+	com.rancher.version="0.5" \
+	com.rancher.repo="https://github.com/rancher/catalog-dockerfiles"
+
+EXPOSE 8000
+ADD contrib/docker/etc/nsswitch.conf /etc/
+
+# Pulled from centurylin/ca-certs source.
+ADD https://raw.githubusercontent.com/CenturyLinkLabs/ca-certs-base-image/master/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENV DATABASE_DRIVER=sqlite3
+ENV DATABASE_CONFIG=/var/lib/drone/drone.sqlite
+
+ADD drone_static /drone_static
+ADD ./scripts/*.sh /opt/rancher/scripts/
+RUN chmod +x /opt/rancher/scripts/*.sh
+
+# default to server though it could also be 'agent'
+ENTRYPOINT ["/opt/rancher/scripts/rancher_drone_entrypoint.sh", "server"]
+
+ADD Dockerfile /opt/rancher/

--- a/drone/containers/0.5/drone/contrib/docker/etc/nsswitch.conf
+++ b/drone/containers/0.5/drone/contrib/docker/etc/nsswitch.conf
@@ -1,0 +1,19 @@
+# /etc/nsswitch.conf
+#
+# Example configuration of GNU Name Service Switch functionality.
+# If you have the `glibc-doc-reference' and `info' packages installed, try:
+# `info libc "Name Service Switch"' for information about this file.
+
+passwd:         compat
+group:          compat
+shadow:         compat
+
+hosts:          files dns
+networks:       files
+
+protocols:      files
+services:       files
+ethers:         files
+rpc:            files
+
+netgroup:       nis

--- a/drone/containers/0.5/drone/scripts/rancher_drone_entrypoint.sh
+++ b/drone/containers/0.5/drone/scripts/rancher_drone_entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ 'agent' == "$1" ] || [ 'server' == "$1" ]; then
+  echo "$0: Starting drone in $1 mode..."
+else
+  echo "$0: Must specify mode of 'agent' or 'server'." >&2 ; exit -1
+fi
+
+while [ ! -e /etc/drone/dronerc ]; do 
+    sleep 1
+done
+
+if [ -n "${DEBUG}" ]; then
+    echo "Contents of /etc/drone/dronerc..."
+    cat /etc/drone/dronerc
+fi
+
+source /etc/drone/dronerc
+
+exec /drone_static $1


### PR DESCRIPTION
Update drone containers:
- for Drone version 0.5
- alpine:3.4
- with newest giddyup
- with newest confd
- with additional metadata per presentations by garethr
- entrypoint scripts now take parameters of 'agent|server' so they can adjust accordingly.

@cloudnautique @will-chan 
