### PR TITLE
Use mongo primary ip instead of hostname and update giddyup

### DIFF
--- a/MongoDB/containers/0.1.0/mongodb-config/Dockerfile
+++ b/MongoDB/containers/0.1.0/mongodb-config/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Hussein Galal
 # install giddyup
 RUN apk add -U curl \
     && mkdir -p /opt/rancher/bin \
-    && curl -L https://github.com/cloudnautique/giddyup/releases/download/v0.14.0/giddyup -o /opt/rancher/bin/giddyup \
+    && curl -L https://github.com/rancher/giddyup/releases/download/v0.16.0/giddyup -o /opt/rancher/bin/giddyup \
     && chmod u+x /opt/rancher/bin/*
 
 ADD ./*.sh /opt/rancher/bin/

--- a/MongoDB/containers/0.1.0/mongodb-config/connect.sh
+++ b/MongoDB/containers/0.1.0/mongodb-config/connect.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -n "$CATTLE_SCRIPT_DEBUG" ]; then 
+if [ -n "$CATTLE_SCRIPT_DEBUG" ]; then
 	set -x
 fi
 
@@ -9,7 +9,8 @@ GIDDYUP=/opt/rancher/bin/giddyup
 function cluster_init {
 	sleep 10
 	MYIP=$($GIDDYUP ip myip)
-	mongo --eval "printjson(rs.initiate())"
+	CONFIG="{_id: \"$MONGO_REPLSET\",version: 1,members: [{ _id: 0, host : \"$MYIP:27017\" }]}"
+	mongo --eval "printjson(rs.initiate($CONFIG))"
 	for member in $($GIDDYUP ip stringify --delimiter " "); do
 		if [ "$member" != "$MYIP" ]; then
 			mongo --eval "printjson(rs.add('$member:27017'))"


### PR DESCRIPTION
@cloudnautique The PR will use Primary node's IP instead of using hostname by default.

https://github.com/rancher/community-catalog/issues/200