### PR TITLE
Updating containers to use DNS names to connect

### DIFF
--- a/MongoDB/containers/0.1.0/mongodb-config/connect.sh
+++ b/MongoDB/containers/0.1.0/mongodb-config/connect.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -n "$CATTLE_SCRIPT_DEBUG" ]; then 
+if [ -n "$CATTLE_SCRIPT_DEBUG" ]; then
 	set -x
 fi
 
@@ -8,10 +8,11 @@ GIDDYUP=/opt/rancher/bin/giddyup
 
 function cluster_init {
 	sleep 10
+	MYNAME=$(hostname)
 	MYIP=$($GIDDYUP ip myip)
 	mongo --eval "printjson(rs.initiate())"
-	for member in $($GIDDYUP ip stringify --delimiter " "); do
-		if [ "$member" != "$MYIP" ]; then
+	for member in $($GIDDYUP service containers); do
+		if [ "$member" != "$MYNAME" ]; then
 			mongo --eval "printjson(rs.add('$member:27017'))"
 			sleep 5
 		fi


### PR DESCRIPTION
This update changes the container discovery to DNS instead of IP. This means that each of the secondary containers will be named in mongod the same way that they are in DNS, not just the initial container. Among other benefits, this allows libraries that expect those to match to function properly; e.g., many libraries discover a master dynamically from a replicaset URI, and those often expect the DNS name to match.