### PR TITLE
The rabbitmq official image is moving docker-entrypoint.sh to /usr/lo…

### DIFF
--- a/rabbitmq/0.1.0/Dockerfile
+++ b/rabbitmq/0.1.0/Dockerfile
@@ -1,0 +1,16 @@
+FROM busybox
+
+ADD https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64 /confd
+RUN chmod +x /confd
+
+ADD ./conf.d /etc/confd/conf.d
+ADD ./templates /etc/confd/templates
+ADD ./run.sh /run.sh
+ADD ./dockerentry.sh /dockerentry.sh
+
+VOLUME /data/confd
+VOLUME /opt/rancher/bin
+VOLUME /etc/rabbitmq
+
+ENTRYPOINT ["/dockerentry.sh"]
+CMD ["--backend", "rancher", "--prefix", "/2015-07-25"]

--- a/rabbitmq/0.1.0/README.md
+++ b/rabbitmq/0.1.0/README.md
@@ -1,0 +1,17 @@
+RabbitMQ 3.6.1 Rancher Docker image
+===
+This template creates and scales out a simple rabbitmq-3.6.1 cluster.
+
+# How it works
+The entrypoint calls `confd` to create `/etc/rabbitmq/rabbitmq.config` file; in the `cluster_nodes` directive lists all the running rabbitmq containers so that the node connects to the others and creates or joins the cluster at startup time.
+
+After deploying the first container, you can scale the service adding new container via Rancher UI.
+
+To access the management interface, point a balancer on the 15672 port of this service.
+
+# TODO
+* Scale down does not remove node from cluster, therefore there will still be a unreachable node
+* Issues adding and removing nodes
+* Issues stopping and starting the stack after adding and removing node
+* ERLANG_COOKIE could be passed via shared volume
+* include more common parameters in config

--- a/rabbitmq/0.1.0/conf.d/rabbitmq.toml
+++ b/rabbitmq/0.1.0/conf.d/rabbitmq.toml
@@ -1,0 +1,7 @@
+[template]
+src = "rabbitmq.tmpl"
+dest = "/etc/rabbitmq/rabbitmq.config"
+keys = [
+  "/self/service",
+  "/containers",
+]

--- a/rabbitmq/0.1.0/dockerentry.sh
+++ b/rabbitmq/0.1.0/dockerentry.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cp /run.sh /opt/rancher/bin/
+
+exec /confd $@

--- a/rabbitmq/0.1.0/run.sh
+++ b/rabbitmq/0.1.0/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec /docker-entrypoint.sh rabbitmq-server

--- a/rabbitmq/0.1.0/templates/rabbitmq.tmpl
+++ b/rabbitmq/0.1.0/templates/rabbitmq.tmpl
@@ -1,0 +1,10 @@
+[
+  {rabbit, [
+    {cluster_nodes,
+        {[
+{{range $idx, $cnt := gets "/self/service/containers/*"}}{{ if (ne $idx 0) }},{{end}} 'rabbit@{{.Value}}'{{end}}
+         ], disc}     },
+  {loopback_users, []}
+  ]
+}].
+

--- a/rabbitmq/0.2.0/Dockerfile
+++ b/rabbitmq/0.2.0/Dockerfile
@@ -1,0 +1,16 @@
+FROM busybox
+
+ADD https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64 /confd
+RUN chmod +x /confd
+
+ADD ./conf.d /etc/confd/conf.d
+ADD ./templates /etc/confd/templates
+ADD ./run.sh /run.sh
+ADD ./dockerentry.sh /dockerentry.sh
+
+VOLUME /data/confd
+VOLUME /opt/rancher/bin
+VOLUME /etc/rabbitmq
+
+ENTRYPOINT ["/dockerentry.sh"]
+CMD ["--backend", "rancher", "--prefix", "/2015-07-25"]

--- a/rabbitmq/0.2.0/README.md
+++ b/rabbitmq/0.2.0/README.md
@@ -1,0 +1,23 @@
+RabbitMQ 3.6 Rancher Docker image
+===
+This template creates and scales out a rabbitmq-3.6 cluster.
+
+# How it works
+The entrypoint calls `confd` to create `/etc/rabbitmq/rabbitmq.config` file; in the `cluster_nodes` directive lists all the running rabbitmq containers so that the node connects to the others and creates or joins the cluster at startup time.
+
+After deploying the first container, you can scale the service adding new container via Rancher UI.
+
+To access the management interface, point a balancer on the 15672 port of this service.
+
+## Environment variables
+The following environment variables are passed to `confd` in order to set up RabbitMQ's  configuration file:
+
+* `RABBITMQ_CLUSTER_PARTITION_HANDLING`: RabbitMQ's cluster handling setting: default set to `autoheal`
+* `RABBITMQ_NET_TICKTIME`: adjusts the frequency of both tick messages and detection of failures: default set to `60`
+* `RABBITMQ_ERLANG_COOKIE`: cookie to allow nodes communication: default set to `defaultcookiepleasechange`
+
+Other two variables are available to fine-tune the cluster or test `confd` configuration:
+
+* `ALTERNATE_CONF`: overrides the whole default `confd` RabbitMQ template: default set to empty
+* `CONFD_ARGS`: additional `confd` args along with default `--backend rancher --prefix /2015-07-25`: default set to `--interval 5`
+

--- a/rabbitmq/0.2.0/conf.d/rabbitmq.toml
+++ b/rabbitmq/0.2.0/conf.d/rabbitmq.toml
@@ -1,0 +1,7 @@
+[template]
+src = "rabbitmq.tmpl"
+dest = "/etc/rabbitmq/rabbitmq.config"
+keys = [
+  "/self/service",
+  "/containers",
+]

--- a/rabbitmq/0.2.0/dockerentry.sh
+++ b/rabbitmq/0.2.0/dockerentry.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cp /run.sh /opt/rancher/bin/
+
+if [[ -v ALTERNATE_CONF ]]; then 
+    echo "Custom template found: overriding internal template";
+    printenv ALTERNATE_CONF > /etc/confd/templates/rabbitmq.tmpl; 
+fi
+
+exec /confd $@ $CONFD_ARGS

--- a/rabbitmq/0.2.0/run.sh
+++ b/rabbitmq/0.2.0/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec /docker-entrypoint.sh rabbitmq-server

--- a/rabbitmq/0.2.0/templates/rabbitmq.tmpl
+++ b/rabbitmq/0.2.0/templates/rabbitmq.tmpl
@@ -1,0 +1,14 @@
+[
+  {rabbit, [
+    {cluster_partition_handling, {{if (getenv "RABBITMQ_CLUSTER_PARTITION_HANDLING")}} {{getenv "RABBITMQ_CLUSTER_PARTITION_HANDLING"}} {{else}} ignore {{end}} },
+    {cluster_nodes,
+        {[
+{{range $idx, $cnt := gets "/self/service/containers/*"}}{{ if (ne $idx 0) }},{{end}} 'rabbit@{{.Value}}'{{end}}
+         ], disc}     },
+  {loopback_users, []}
+  ]},
+  {kernel, [
+    {net_ticktime, {{if (getenv "RABBITMQ_NET_TICKTIME")}} {{getenv "RABBITMQ_NET_TICKTIME"}} {{else}} 60 {{end}} }
+  ]}
+].
+

--- a/rabbitmq/0.2.1/Dockerfile
+++ b/rabbitmq/0.2.1/Dockerfile
@@ -1,0 +1,16 @@
+FROM busybox
+
+ADD https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64 /confd
+RUN chmod +x /confd
+
+ADD ./conf.d /etc/confd/conf.d
+ADD ./templates /etc/confd/templates
+ADD ./run.sh /run.sh
+ADD ./dockerentry.sh /dockerentry.sh
+
+VOLUME /data/confd
+VOLUME /opt/rancher/bin
+VOLUME /etc/rabbitmq
+
+ENTRYPOINT ["dockerentry.sh"]
+CMD ["--backend", "rancher", "--prefix", "/2015-07-25"]

--- a/rabbitmq/0.2.1/README.md
+++ b/rabbitmq/0.2.1/README.md
@@ -1,0 +1,23 @@
+RabbitMQ 3.6 Rancher Docker image
+===
+This template creates and scales out a rabbitmq-3.6 cluster.
+
+# How it works
+The entrypoint calls `confd` to create `/etc/rabbitmq/rabbitmq.config` file; in the `cluster_nodes` directive lists all the running rabbitmq containers so that the node connects to the others and creates or joins the cluster at startup time.
+
+After deploying the first container, you can scale the service adding new container via Rancher UI.
+
+To access the management interface, point a balancer on the 15672 port of this service.
+
+## Environment variables
+The following environment variables are passed to `confd` in order to set up RabbitMQ's  configuration file:
+
+* `RABBITMQ_CLUSTER_PARTITION_HANDLING`: RabbitMQ's cluster handling setting: default set to `autoheal`
+* `RABBITMQ_NET_TICKTIME`: adjusts the frequency of both tick messages and detection of failures: default set to `60`
+* `RABBITMQ_ERLANG_COOKIE`: cookie to allow nodes communication: default set to `defaultcookiepleasechange`
+
+Other two variables are available to fine-tune the cluster or test `confd` configuration:
+
+* `ALTERNATE_CONF`: overrides the whole default `confd` RabbitMQ template: default set to empty
+* `CONFD_ARGS`: additional `confd` args along with default `--backend rancher --prefix /2015-07-25`: default set to `--interval 5`
+

--- a/rabbitmq/0.2.1/conf.d/rabbitmq.toml
+++ b/rabbitmq/0.2.1/conf.d/rabbitmq.toml
@@ -1,0 +1,7 @@
+[template]
+src = "rabbitmq.tmpl"
+dest = "/etc/rabbitmq/rabbitmq.config"
+keys = [
+  "/self/service",
+  "/containers",
+]

--- a/rabbitmq/0.2.1/dockerentry.sh
+++ b/rabbitmq/0.2.1/dockerentry.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cp /run.sh /opt/rancher/bin/
+
+if [[ -v ALTERNATE_CONF ]]; then 
+    echo "Custom template found: overriding internal template";
+    printenv ALTERNATE_CONF > /etc/confd/templates/rabbitmq.tmpl; 
+fi
+
+exec /confd $@ $CONFD_ARGS

--- a/rabbitmq/0.2.1/run.sh
+++ b/rabbitmq/0.2.1/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec /usr/local/bin/docker-entrypoint.sh rabbitmq-server

--- a/rabbitmq/0.2.1/templates/rabbitmq.tmpl
+++ b/rabbitmq/0.2.1/templates/rabbitmq.tmpl
@@ -1,0 +1,14 @@
+[
+  {rabbit, [
+    {cluster_partition_handling, {{if (getenv "RABBITMQ_CLUSTER_PARTITION_HANDLING")}} {{getenv "RABBITMQ_CLUSTER_PARTITION_HANDLING"}} {{else}} ignore {{end}} },
+    {cluster_nodes,
+        {[
+{{range $idx, $cnt := gets "/self/service/containers/*"}}{{ if (ne $idx 0) }},{{end}} 'rabbit@{{.Value}}'{{end}}
+         ], disc}     },
+  {loopback_users, []}
+  ]},
+  {kernel, [
+    {net_ticktime, {{if (getenv "RABBITMQ_NET_TICKTIME")}} {{getenv "RABBITMQ_NET_TICKTIME"}} {{else}} 60 {{end}} }
+  ]}
+].
+


### PR DESCRIPTION
The rabbitmq official image is moving docker-entrypoint.sh to `/usr/local/bin`, while in the debian they retain backward compat, the alpine image fails because it does not 
https://github.com/docker-library/rabbitmq/blob/79277042564875d55e4b05a60c65b6eb46651a94/3.6/debian/Dockerfile#L89  and I'm not certain why this rabbitmq directory is not in here anymore as there was a merged [PR](https://github.com/rancher/community-catalog/pull/280/files)  it was probably removed for a reason and I'm just being dim inserting code you don't want for some reason back into the repos, regardless the issue above remains.

Perhaps this does deserve it's own repo, this should perhaps be owned by the rancher organization but here's what I did to get it to work:

get rid of the folders 0.1.0 etc here and make a new repo with those as tags:
https://github.com/WebHostingCoopTeam/rabbitmq-conf
corresponding tags on dockerhub:
https://hub.docker.com/r/webhostingcoopteam/rabbitmq-conf/tags/
and a template to test it all out:
https://github.com/WebHostingCoopTeam/whc-catalog/tree/master/templates/rabbitmq-3

with a PR to follow in the community-catalog